### PR TITLE
style: align tasks side by side in hour slots

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -569,3 +569,18 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 }
 /* Completed = softly filled, easy to see */
 .task.done{ background:#eef8ff; border-color:#cfeaff; color:#374151; }
+
+/* --- Hour summary: side-by-side tasks --- */
+.hour-summary{
+  display:flex !important;
+  flex-direction:row !important;
+  flex-wrap:wrap;
+  gap:8px !important;
+}
+.hour-summary .task,
+.hour-dropzone .task{
+  width:auto !important;
+  max-width:100% !important;
+  margin:0 !important;
+}
+.hour-summary .task + .task{ margin-top:0 !important; }


### PR DESCRIPTION
## Summary
- display hour slots as flex rows so dropped tasks sit side by side
- reset task card widths and margins for clean wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2b2ee64832784045fa028975017