### PR TITLE
fix: show real task titles in hour summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -464,7 +464,9 @@
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'summary-chip';
-      btn.textContent = 'Task ' + (i+1);
+      const txt = $('.task-text', tasks[i])?.textContent.trim() || ('Task ' + (i+1));
+      btn.textContent = txt.length > 20 ? txt.slice(0,20).trim() + '…' : txt;
+      btn.title = txt;
       btn.addEventListener('click', e=>{ e.stopPropagation(); openModal([tasks[i]]); });
       bar.appendChild(btn);
     }

--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,12 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
   border:1px solid #d0d7de; border-radius:12px; background:#fff; font-size:12px; cursor:pointer;
 }
 .hour-summary .view-all-btn { background:#f7f7f7; }
+.hour-summary .summary-chip {
+  max-width:150px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
 
 #fd-modal-list{ display:flex; flex-direction:column; gap:8px; }
 


### PR DESCRIPTION
## Summary
- show actual task text on hour summary chips instead of generic labels
- truncate long task names and ellipsize them for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bbf19d1883279d5e8666aa347712