### PR TITLE
Add responsive breakpoints for small viewports

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,56 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 
 @media (max-width:1100px){.boards{grid-template-columns:1fr}.palette{order:2}.day-grid{order:1}.main-goal-input{min-width:240px;width:100%}}
 
+@media (max-width:768px){
+  .app-header,
+  .app-footer{
+    flex-wrap:wrap;
+    gap:8px;
+    padding:8px 12px;
+  }
+  .app-header .left,
+  .app-header .center,
+  .app-header .right{
+    flex:1 1 100%;
+    justify-content:space-between;
+    flex-wrap:wrap;
+  }
+  .boards{grid-template-columns:1fr;}
+  .palette{max-width:340px;margin:0 auto;}
+  .main-goal-input{min-width:0;width:100%;}
+  .add-row{flex-wrap:wrap;}
+}
+
+@media (max-width:600px){
+  .app-header,
+  .app-footer{
+    flex-direction:column;
+    align-items:flex-start;
+    padding:6px 8px;
+    gap:6px;
+  }
+  .app-header .left,
+  .app-header .center,
+  .app-header .right{
+    width:100%;
+    flex-direction:column;
+    align-items:stretch;
+    gap:6px;
+  }
+  .boards{grid-template-columns:1fr;}
+  .palette{max-width:280px;margin:0 auto;}
+  input[type="date"],
+  .main-goal-input,
+  .add-row input,
+  .cat-select{
+    width:100%;
+    min-width:0;
+  }
+  #newTaskInput,
+  #customCat,
+  .cat-select{flex:1 1 100%;}
+}
+
 /* --- Fix: keep + in the Add row (no overflow into the grid) --- */
 .add-row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 #newTaskInput{flex:1 1 200px;min-width:0}


### PR DESCRIPTION
## Summary
- Add CSS breakpoints at 768px and 600px to improve narrow-screen layout
- Stack header sections, simplify boards grid, and constrain palette width at small sizes
- Ensure inputs and controls wrap or stretch without overflow on tiny screens

## Testing
- `npx playwright --help` *(fails: 403 Forbidden - package access blocked)*
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa002ba92483279a2c3b138b4aff16