### PR TITLE
Add aria labels to icon-only buttons for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,13 @@
   <div id="app">
     <header class="app-header">
       <div class="left">
-        <button id="prevDay" title="Previous day">◀</button>
+        <button id="prevDay" title="Previous day" aria-label="Previous day">
+          ◀<span class="visually-hidden">Previous day</span>
+        </button>
         <input type="date" id="datePicker" />
-        <button id="nextDay" title="Next day">▶</button>
+        <button id="nextDay" title="Next day" aria-label="Next day">
+          ▶<span class="visually-hidden">Next day</span>
+        </button>
       </div>
       <div class="center">
         <input id="mainGoal" class="main-goal-input" type="text" placeholder="Main goal for today…" />
@@ -32,7 +36,9 @@
           <input id="newTaskInput" type="text" placeholder="Add a task and press Enter" />
           <select id="catSelect" class="cat-select" title="Category"></select>
           <input id="customCat" class="custom-cat" type="text" placeholder="New category name…" style="display:none" />
-          <button id="addTaskBtn">＋</button>
+          <button id="addTaskBtn" title="Add task" aria-label="Add task">
+            ＋<span class="visually-hidden">Add task</span>
+          </button>
           <button id="manageCatsBtn" class="ghost-btn" title="Manage categories">Manage</button>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
 }
 *{box-sizing:border-box} html,body,#app{height:100%}
 body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,Noto Sans;color:var(--text);background:var(--bg)}
+.visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 .app-header,.app-footer{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px;background:var(--panel);border-bottom:1px solid var(--grid-line);position:sticky;top:0;z-index:10}
 .app-footer{border-top:1px solid var(--grid-line);border-bottom:none;bottom:0;top:auto}


### PR DESCRIPTION
## Summary
- Improve accessibility by adding `aria-label` and hidden text to icon-only navigation and add-task buttons
- Introduce `.visually-hidden` utility class for screen-reader-only text

## Testing
- `npx @axe-core/cli index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@axe-core%2fcli)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa004177d0832792ebc8655b8c26e8