### PR TITLE
Refresh hour task layout after page load

### DIFF
--- a/app.js
+++ b/app.js
@@ -233,6 +233,7 @@
 
       updateCategorySelect();
       document.dispatchEvent(new Event('fdDayGridRendered'));
+      if(typeof window.fdRefreshAll==='function') window.fdRefreshAll();
     }
 
     // ---- add task ----


### PR DESCRIPTION
## Summary
- ensure `render()` triggers `fdRefreshAll` to rebuild hour task chips after each render

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1287ff448327b2fef10a72b6a13d