### PR TITLE
style: wrap hour tasks in flex lanes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,9 +32,25 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 
 .day-grid{background:var(--panel);border:1px solid var(--grid-line);border-radius:14px;padding:0;display:grid;grid-template-columns:80px 1fr;height:100%;overflow:auto;position:relative;z-index:1}
 .hour-label{padding:10px 8px;color:var(--muted);border-right:1px solid var(--grid-line);border-bottom:1px solid var(--grid-line);text-align:right;background:#fff}
-.hour-dropzone{position:relative;padding:6px 10px;min-height:38px;border-bottom:1px solid var(--grid-line);background:transparent}
+.hour-dropzone{
+  position:relative;
+  min-height:84px;
+  padding:8px 10px 12px;
+  border-radius:10px;
+  border:1px solid var(--border,#e5e7eb);
+  background:var(--hour-bg,#fff);
+}
 .hour-dropzone.drag-over{background:var(--drop)}
-.hour-dropzone .task-list{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
+
+.task-lane{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:8px;
+  overflow-x:auto;
+  overflow-y:hidden;
+  white-space:normal;
+}
 .hour-dropzone:not(.has-tasks)::before{
   content:"(No tasks)";
   color:var(--muted);
@@ -43,8 +59,49 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 }
 
 /* task chip styling */
-.task-chip{display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:999px;white-space:nowrap;max-width:140px;overflow:hidden;text-overflow:ellipsis}
+
+.task-chip{
+  flex:0 0 auto;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 10px;
+  height:32px;
+  border-radius:999px;
+  background:#f5f7fb;
+  border:1px solid #dfe3ea;
+  box-shadow:0 1px 0 rgba(0,0,0,.04);
+  cursor:grab;
+  user-select:none;
+  pointer-events:auto;
+  z-index:0;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
 .task-chip.all-chip{font-weight:600}
+
+.task-chip.dragging{
+  opacity:.85;
+  cursor:grabbing;
+  position:fixed;
+  z-index:1000;
+}
+
+.task-chip .title{
+  max-width:180px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.task-chip .time-badge{
+  font-variant-numeric:tabular-nums;
+  font-size:12px;
+  padding:2px 6px;
+  background:#fff;
+  border:1px solid #e5e7eb;
+  border-radius:6px;
+}
 
 /* drag preview ghost */
 .drag-preview{position:fixed;pointer-events:none;z-index:9999}


### PR DESCRIPTION
## Summary
- use `.task-lane` flex containers in hour slots for wrapping chips
- style chips as self-sized pills and add drag handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa15bb4d248327ba5fa417497346f2