### PR TITLE
Add task detail modal and hour view button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,18 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 }
 .hour-dropzone.drag-over{background:var(--drop)}
 
+.hour-view-btn{
+  position:absolute;
+  top:4px;
+  right:4px;
+  width:24px;
+  height:24px;
+  padding:0;
+  border-radius:6px;
+  font-size:16px;
+  line-height:1;
+}
+
 .task-lane{
   display:flex;
   flex-wrap:wrap;


### PR DESCRIPTION
## Summary
- show task details with actions when clicking a task chip or task
- add button in each hour slot to list tasks for that hour
- style hour-slot button

## Testing
- `node --check app.js && echo 'syntax ok'`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ce69a908327a348cd082cc1a39e