### PR TITLE
Ensure task modal persists and add hour task view button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -214,6 +214,7 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 
 
 #fd-modal-list{ display:flex; flex-direction:column; gap:8px; }
+#fd-modal-list .hour-all-btn{ align-self:flex-start; margin-top:8px; }
 
 /* Optional toast */
 .fd-toast { position:fixed; left:50%; bottom:16px; transform:translateX(-50%);


### PR DESCRIPTION
## Summary
- ensure task details modal can always render from app state, keeping it functional after task moves
- add button in task modal to view all tasks in the same hour
- style new hour view button

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa60346f188327ad9470c4e67aaf36