### PR TITLE
fix: improve task modal layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -464,20 +464,6 @@ document.addEventListener(
   }
 })();
 
-function dropIntoHour(slotEl, chipEl) {
-  chipEl.style.position = '';
-  chipEl.style.transform = '';
-  chipEl.style.left = '';
-  chipEl.style.top = '';
-  chipEl.classList.add('task-chip');
-
-  const list =
-    slotEl.querySelector('.task-lane') ||
-    slotEl.appendChild(Object.assign(document.createElement('div'), { className: 'task-lane' }));
-
-  list.appendChild(chipEl);
-}
-
 function onDragEnd() {
   document.querySelectorAll('.drag-preview').forEach(el => el.remove());
 }
@@ -488,9 +474,10 @@ function onDragEnd() {
   const $  = (s,r=document)=>r.querySelector(s);
   const $$ = (s,r=document)=>Array.from(r.querySelectorAll(s));
 
-  function openModal(nodes, attach=true){
+  function openModal(nodes, attach=true, title=''){
     const modal = $('#hourModal'); if(!modal) return;
     const list  = $('#fd-modal-list'); list.innerHTML = '';
+    const ttl = $('#fd-modal-title'); if(ttl) ttl.textContent = title;
     nodes.forEach(n=>{
       const clone = n.cloneNode(true);
       clone.removeAttribute('draggable');
@@ -516,7 +503,7 @@ function onDragEnd() {
   function openHourModal(slotId){
     const dz = document.querySelector('.hour-dropzone[data-hour="'+slotId+'"]');
     if(!dz) return;
-    openModal($$('.task', dz), true);
+    openModal($$('.task', dz), true, 'Tasks at '+slotId);
   }
 
   function openTaskModal(taskId){
@@ -527,7 +514,7 @@ function onDragEnd() {
     if(!task) return;
     const hour = window.fdFindTaskHour ? window.fdFindTaskHour(taskId) : null;
     const node = makeNode(task, !!hour);
-    openModal([node], false);
+    openModal([node], false, task.text || 'Task');
     if(hour){
       const list = document.getElementById('fd-modal-list');
       if(list){
@@ -579,8 +566,13 @@ function onDragEnd() {
 
     // move tasks into list (hidden) and reset positioning
     tasks.forEach(t=>{
-      dropIntoHour(dz, t);
+      t.classList.remove('task-chip');
+      t.style.position = '';
+      t.style.transform = '';
+      t.style.left = '';
+      t.style.top = '';
       t.style.display='none';
+      list.appendChild(t);
     });
 
     const MAX_VISIBLE = 3;

--- a/index.html
+++ b/index.html
@@ -96,13 +96,14 @@
     </div>
   </template>
 
-  <div id="hourModal" style="display:none">
-    <div class="fd-modal-backdrop"></div>
-    <div class="fd-modal-panel">
-      <button class="fd-modal-close" aria-label="Close">✕</button>
-      <div id="fd-modal-list"></div>
+    <div id="hourModal" style="display:none">
+      <div class="fd-modal-backdrop"></div>
+      <div class="fd-modal-panel">
+        <button class="fd-modal-close" aria-label="Close">✕</button>
+        <h3 id="fd-modal-title"></h3>
+        <div id="fd-modal-list"></div>
+      </div>
     </div>
-  </div>
 
   <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -215,6 +215,7 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 
 #fd-modal-list{ display:flex; flex-direction:column; gap:8px; }
 #fd-modal-list .hour-all-btn{ align-self:flex-start; margin-top:8px; }
+#fd-modal-title{ margin:0 0 12px; font-size:18px; }
 
 /* Optional toast */
 .fd-toast { position:fixed; left:50%; bottom:16px; transform:translateX(-50%);


### PR DESCRIPTION
## Summary
- ensure tasks in hour view retain full card styling and reset positioning
- add dynamic modal title for single tasks and hourly views for clearer popups

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa6d9ef3508327bf0c8206ffd75acb