### PR TITLE
fix: enable dragging tasks between areas

### DIFF
--- a/app.js
+++ b/app.js
@@ -365,7 +365,13 @@ document.addEventListener(
   e => {
     const t = e.target.closest?.('.task, .task-chip');
     if (!t) return;
-    state.draggingId = t.dataset.id || t.dataset.taskid;
+    const id = t.dataset.id || t.dataset.taskid || '';
+    state.draggingId = id;
+    // ensure some data is set so that dragging works across browsers
+    if (e.dataTransfer) {
+      e.dataTransfer.setData('text/plain', id);
+      e.dataTransfer.effectAllowed = 'move';
+    }
     if (t.classList.contains('task-chip')) {
       t.classList.add('dragging');
       t.style.width = t.getBoundingClientRect().width + 'px';


### PR DESCRIPTION
## Summary
- ensure dragstart sets dataTransfer info so task chips can be moved across drop zones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa945c2d5c83279087c5a1e59f41f0