### PR TITLE
Clean drag-over styling on drag end

### DIFF
--- a/app.js
+++ b/app.js
@@ -391,6 +391,7 @@ document.addEventListener(
     }
     state.draggingId = null;
     onDragEnd();
+    document.querySelectorAll('.droppable').forEach(el => el.classList.remove('drag-over'));
   },
   true
 );


### PR DESCRIPTION
## Summary
- Ensure drag-over styling cleared from all droppable zones when a drag ends

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa00cbe2c83278f350a609d676360