### PR TITLE
Use newId in drop copy handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -402,7 +402,7 @@ document.addEventListener(
       const copy=e.ctrlKey||e.metaKey||e.altKey||e.shiftKey;
       let moved=getTaskById(id); if(!moved) return;
       if(copy){
-        moved={ id:Math.random().toString(36).slice(2,9), text:moved.text, done:false, cat:moved.cat, timer:{elapsed:0,running:false,startedAt:null} };
+        moved={ id:newId(), text:moved.text, done:false, cat:moved.cat, timer:{elapsed:0,running:false,startedAt:null} };
       }else{
         removeEverywhere(id);
       }


### PR DESCRIPTION
## Summary
- replace inline `Math.random()` when duplicating tasks in drop handler with reusable `newId()`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa00ec11c8327911faf5cfa556c4f