### PR TITLE
Align drag ghost with cursor

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,8 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 /* drag preview ghost */
 .drag-preview{position:fixed;pointer-events:none;z-index:9999}
 
+.drag-image{position:fixed;pointer-events:none;z-index:1000}
+
 /* backlog drag placeholder */
 .drag-placeholder{background:var(--panel-2);border:2px dashed var(--accent);border-radius:10px;height:38px;margin:6px 6px 6px 0}
 


### PR DESCRIPTION
## Summary
- Ensure drag preview node follows cursor by tracking initial offset
- Hide native drag image and use custom `drag-image` style for consistent ghost positioning

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aab5bf80048327aaaf3cc0b241e708