### PR TITLE
fix: drag preview follows cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.bak
+node_modules
+test-results/
+playwright-report/

--- a/app.js
+++ b/app.js
@@ -367,6 +367,7 @@ document.addEventListener(
     if (!t) return;
     const id = t.dataset.id || t.dataset.taskid || '';
     state.draggingId = id;
+    t.classList.add('dragging');
     // ensure some data is set so that dragging works across browsers
     if (e.dataTransfer) {
       // Older Edge browsers only recognize 'text'
@@ -392,17 +393,8 @@ document.addEventListener(
         node.style.top = e.clientY - offsetY + 'px';
         document.body.appendChild(node);
         state.dragPreviewEl = node;
-        const img = new Image();
-        img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-        try { e.dataTransfer.setDragImage(img, 0, 0); } catch (err) {}
+        try { e.dataTransfer.setDragImage(node, offsetX, offsetY); } catch (err) {}
       }
-    }
-    if (t.classList.contains('task-chip')) {
-      const chipRect = t.getBoundingClientRect();
-      t.classList.add('dragging');
-      t.style.width = chipRect.width + 'px';
-      t.style.left = e.clientX - state.dragOffsetX + 'px';
-      t.style.top = e.clientY - state.dragOffsetY + 'px';
     }
   },
   true
@@ -410,12 +402,9 @@ document.addEventListener(
 document.addEventListener(
   'dragend',
   e => {
-    const t = e.target.closest?.('.task-chip');
+    const t = e.target.closest?.('.task, .task-chip');
     if (t) {
       t.classList.remove('dragging');
-      t.style.width = '';
-      t.style.top = '';
-      t.style.left = '';
     }
     state.draggingId = null;
     state.backlogPlaceholderIndex = null;
@@ -430,15 +419,10 @@ document.addEventListener(
   },
   true
 );
-  document.addEventListener('dragover', e => {
+document.addEventListener('dragover', e => {
     if (state.dragPreviewEl) {
       state.dragPreviewEl.style.left = e.clientX - state.dragOffsetX + 'px';
       state.dragPreviewEl.style.top = e.clientY - state.dragOffsetY + 'px';
-    }
-    const chip = document.querySelector('.task-chip.dragging');
-    if (chip) {
-      chip.style.left = e.clientX - state.dragOffsetX + 'px';
-      chip.style.top = e.clientY - state.dragOffsetY + 'px';
     }
   }, true);
   document.addEventListener('dragover', e => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "focusday-web-clean",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.44.0"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -95,11 +95,10 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 }
 .task-chip.all-chip{font-weight:600}
 
+
+.task.dragging,
 .task-chip.dragging{
-  opacity:.85;
-  cursor:grabbing;
-  position:fixed;
-  z-index:1000;
+  opacity:.6;
 }
 
 .task-chip .title{

--- a/tests/drag-preview.spec.js
+++ b/tests/drag-preview.spec.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+test('drag preview follows cursor', async ({ page }) => {
+  const file = 'file://' + path.resolve(__dirname, '../index.html');
+  await page.goto(file);
+  // add a task
+  await page.fill('#newTaskInput', 'Test task');
+  await page.click('#addTaskBtn');
+  const locator = page.locator('#backlog .task').first();
+  await locator.waitFor();
+  const box = await locator.boundingBox();
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+  const startX = box.x + 10;
+  const startY = box.y + 10;
+  await page.dispatchEvent('#backlog .task', 'dragstart', {
+    clientX: startX,
+    clientY: startY,
+    dataTransfer
+  });
+  const moveX = startX + 50;
+  const moveY = startY + 30;
+  await page.dispatchEvent('body', 'dragover', {
+    clientX: moveX,
+    clientY: moveY,
+    dataTransfer
+  });
+  const preview = page.locator('.drag-image');
+  const pos = await preview.evaluate(el => ({
+    left: parseFloat(el.style.left),
+    top: parseFloat(el.style.top)
+  }));
+  expect(Math.abs(pos.left - (moveX - 10))).toBeLessThanOrEqual(2);
+  expect(Math.abs(pos.top - (moveY - 10))).toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary
- eliminate drag preview offset by applying `setDragImage` with cursor offsets
- dim dragging source with `.dragging` class
- test drag preview tracks cursor within tolerance

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac4fc76848327bc91a9dd41e5e9be