### PR TITLE
Fix drag chip alignment and layout in hourly slots

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,6 +359,15 @@
       }
     }
 
+    // Determine insertion index for a chip based on cursor X position
+    function chipIndexFromX(chips, x){
+      for(let i=0;i<chips.length;i++){
+        const rect = chips[i].getBoundingClientRect();
+        if(x < rect.left + rect.width/2) return i;
+      }
+      return chips.length;
+    }
+
     // ---- DnD for tasks ----
 document.addEventListener(
   'dragstart',
@@ -468,14 +477,9 @@ document.addEventListener('dragover', e => {
           lane.className = 'task-lane';
           dz.appendChild(lane);
         }
-        const chips = Array.from(lane.querySelectorAll('.task-chip')).filter(c => c.dataset.taskid !== id && !c.classList.contains('dragging'));
-        let index = chips.length;
-        const target = e.target.closest('.task-chip');
-        if (target && lane.contains(target)) {
-          const rect = target.getBoundingClientRect();
-          const before = e.clientX < rect.left + rect.width / 2;
-          index = chips.indexOf(target) + (before ? 0 : 1);
-        }
+        const chips = Array.from(lane.querySelectorAll('.task-chip'))
+          .filter(c => c.dataset.taskid !== id && !c.classList.contains('dragging'));
+        const index = chipIndexFromX(chips, e.clientX);
         const preview = document.createElement('div');
         preview.className = 'task-chip drag-preview';
         preview.style.position = 'static';
@@ -537,14 +541,7 @@ document.addEventListener('dragover', e => {
         const list = slots.filter(Boolean);
         const lane = dz.querySelector('.task-lane');
         const chips = lane ? Array.from(lane.querySelectorAll('.task-chip')).filter(c => !c.classList.contains('drag-preview')) : [];
-        const target = e.target.closest('.task-chip:not(.drag-preview)');
-        let dest = list.length;
-        if (target && chips.includes(target)) {
-          const rect = target.getBoundingClientRect();
-          const before = e.clientX < rect.left + rect.width / 2;
-          const intoIdx = chips.indexOf(target);
-          dest = intoIdx + (before ? 0 : 1);
-        }
+        const dest = chipIndexFromX(chips, e.clientX);
         list.splice(dest, 0, moved);
         const trimmed = list.slice(0, 4);
         for (let i = 0; i < 4; i++) slots[i] = trimmed[i] || null;

--- a/styles.css
+++ b/styles.css
@@ -61,7 +61,8 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
   flex-wrap:wrap;
   align-items:center;
   gap:8px;
-  overflow-x:auto;
+  /* allow chips to wrap onto new lines without forcing horizontal scroll */
+  overflow-x:visible;
   overflow-y:hidden;
   white-space:normal;
 }
@@ -92,6 +93,7 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
+  max-width:200px;
 }
 .task-chip.all-chip{font-weight:600}
 
@@ -99,6 +101,8 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 .task.dragging,
 .task-chip.dragging{
   opacity:.6;
+  /* prevent dragged element from capturing pointer events */
+  pointer-events:none;
 }
 
 .task-chip .title{


### PR DESCRIPTION
## Summary
- ensure drag chips insert relative to container instead of individual tasks
- keep dragged element from intercepting events and let chips wrap with ellipsis

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac9966a4483279830506a848f224d