### PR TITLE
Add animated task timer toggle

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -217,10 +217,21 @@ input[type="date"],.main-goal-input,.add-row input,.cat-select{background:var(--
 .timer-btn{
   border:1px solid var(--grid-line); background:#fff; border-radius:8px;
   padding:2px 6px; line-height:1.2; cursor:pointer;
+  transition:transform 120ms ease, box-shadow 200ms ease, background 200ms ease;
+  outline:none;
+}
+.timer-btn.running{
+  background:#e7f5ff;
+  box-shadow:0 0 0 3px rgba(30,144,255,.25);
 }
 .timer-btn:hover{border-color:var(--accent)}
-.timer-btn.play{ }
-.timer-btn.pause{ }
+.timer-btn:active{transform:scale(0.97);}
+.timer-btn.pop{animation:pop 180ms ease-out;}
+@keyframes pop{
+  0%{transform:scale(0.94);box-shadow:0 0 0 0 rgba(30,144,255,.5);}
+  60%{transform:scale(1.06);box-shadow:0 0 0 6px rgba(30,144,255,.3);}
+  100%{transform:scale(1);box-shadow:0 0 0 0 rgba(30,144,255,0);}
+}
 .timer-btn.reset{ }
 
 


### PR DESCRIPTION
## Summary
- use high-resolution timers with `requestAnimationFrame` for smooth updates
- replace separate play/pause with single animated toggle button and reset
- style timer button with pop/glow animation and active running state

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist)*
- `npx playwright install --with-deps` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac160530fc8327958b57898364df29